### PR TITLE
Changed login page cancel button to danger colour

### DIFF
--- a/src/ts/react/login.tsx
+++ b/src/ts/react/login.tsx
@@ -134,7 +134,9 @@ export class Login extends React.Component<
             </a>
           </DialogContent>
           <DialogActions>
-            <Button
+          <Button
+              color="error" // changed to red for danger/cancel indication
+              variant="outlined" // optional for a bordered style; use "contained" for solid red
               onClick={() =>
                 this.setState({ openAddSlotManuallyDialog: false })
               }


### PR DESCRIPTION
This pull request updates the "Cancel" button styling in the slot input dialog to visually indicate a more dangerous or warning action, aligning with standard UI/UX practices for cancel/close actions.